### PR TITLE
Migrate to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.0.0] 
+* Migrate to null safety
+
 ## [2.0.1+1] - Dart 2.10 and pub.dev compliance
 
 ## [2.0.1] - 2020-04-23

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  exclude:
+     - "**/*.g.dart"
 
 linter:
   rules:
@@ -11,7 +13,6 @@ linter:
     - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_annotating_with_dynamic
-    - avoid_as
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors

--- a/lib/src/package_dependency/dependency_type/serializers.dart
+++ b/lib/src/package_dependency/dependency_type/serializers.dart
@@ -27,11 +27,11 @@ import 'definition.dart';
 
 // ignore_for_file: public_member_api_docs
 
-extension StringToDependencyType on String {
-  DependencyType parseDependencyType() => _dependencyTypeMap[this];
+extension StringToDependencyType on String? {
+  DependencyType? parseDependencyType() => _dependencyTypeMap[this!];
 }
 
-extension DependencyTypeToJson on DependencyType {
+extension DependencyTypeToJson on DependencyType? {
   String format() {
     switch (this) {
       case DependencyType.direct:
@@ -40,8 +40,9 @@ extension DependencyTypeToJson on DependencyType {
         return '"${_Tokens.directDev}"';
       case DependencyType.transitive:
         return _Tokens.transitive;
+      case null:
+        throw AssertionError(this);
     }
-    throw AssertionError(this);
   }
 }
 

--- a/lib/src/package_dependency/git_package_dependency/git_package_dependency.dart
+++ b/lib/src/package_dependency/git_package_dependency/git_package_dependency.dart
@@ -38,22 +38,22 @@ part 'git_package_dependency.g.dart';
 class GitPackageDependency extends $GitPackageDependency {
   /// Default constructor
   const GitPackageDependency({
-    @required this.package,
-    @required this.version,
-    @required this.ref,
-    @required this.url,
-    @required this.path,
-    @required this.resolvedRef,
-    @required this.type,
+    required this.package,
+    required this.version,
+    required this.ref,
+    required this.url,
+    required this.path,
+    required this.resolvedRef,
+    required this.type,
   });
 
   final String package;
-  final String version;
+  final String? version;
 
-  final String ref;
-  final String url;
-  final String path;
-  final String resolvedRef;
+  final String? ref;
+  final String? url;
+  final String? path;
+  final String? resolvedRef;
 
-  final DependencyType type;
+  final DependencyType? type;
 }

--- a/lib/src/package_dependency/git_package_dependency/git_package_dependency.g.dart
+++ b/lib/src/package_dependency/git_package_dependency/git_package_dependency.g.dart
@@ -6,27 +6,25 @@ part of 'git_package_dependency.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $GitPackageDependency {
   const $GitPackageDependency();
+
   String get package;
-  String get version;
-  String get ref;
-  String get url;
-  String get path;
-  String get resolvedRef;
-  DependencyType get type;
+  String? get version;
+  String? get ref;
+  String? get url;
+  String? get path;
+  String? get resolvedRef;
+  DependencyType? get type;
+
   GitPackageDependency copyWith(
-          {String package,
-          String version,
-          String ref,
-          String url,
-          String path,
-          String resolvedRef,
-          DependencyType type}) =>
+          {String? package,
+          String? version,
+          String? ref,
+          String? url,
+          String? path,
+          String? resolvedRef,
+          DependencyType? type}) =>
       GitPackageDependency(
           package: package ?? this.package,
           version: version ?? this.version,
@@ -35,11 +33,15 @@ abstract class $GitPackageDependency {
           path: path ?? this.path,
           resolvedRef: resolvedRef ?? this.resolvedRef,
           type: type ?? this.type);
+
   @override
   String toString() =>
       "GitPackageDependency(package: $package, version: $version, ref: $ref, url: $url, path: $path, resolvedRef: $resolvedRef, type: $type)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is GitPackageDependency &&
       other.runtimeType == runtimeType &&
       package == other.package &&
       version == other.version &&
@@ -48,7 +50,9 @@ abstract class $GitPackageDependency {
       path == other.path &&
       resolvedRef == other.resolvedRef &&
       type == other.type;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + package.hashCode;
@@ -62,30 +66,41 @@ abstract class $GitPackageDependency {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class GitPackageDependency$ {
   static final package = Lens<GitPackageDependency, String>(
-      (s_) => s_.package, (s_, package) => s_.copyWith(package: package));
-  static final version = Lens<GitPackageDependency, String>(
-      (s_) => s_.version, (s_, version) => s_.copyWith(version: version));
-  static final ref = Lens<GitPackageDependency, String>(
-      (s_) => s_.ref, (s_, ref) => s_.copyWith(ref: ref));
-  static final url = Lens<GitPackageDependency, String>(
-      (s_) => s_.url, (s_, url) => s_.copyWith(url: url));
-  static final path = Lens<GitPackageDependency, String>(
-      (s_) => s_.path, (s_, path) => s_.copyWith(path: path));
-  static final resolvedRef = Lens<GitPackageDependency, String>(
-      (s_) => s_.resolvedRef,
-      (s_, resolvedRef) => s_.copyWith(resolvedRef: resolvedRef));
-  static final type = Lens<GitPackageDependency, DependencyType>(
-      (s_) => s_.type, (s_, type) => s_.copyWith(type: type));
-}
+    (packageContainer) => packageContainer.package,
+    (packageContainer, package) => packageContainer.copyWith(package: package),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final version = Lens<GitPackageDependency, String?>(
+    (versionContainer) => versionContainer.version,
+    (versionContainer, version) => versionContainer.copyWith(version: version),
+  );
+
+  static final ref = Lens<GitPackageDependency, String?>(
+    (refContainer) => refContainer.ref,
+    (refContainer, ref) => refContainer.copyWith(ref: ref),
+  );
+
+  static final url = Lens<GitPackageDependency, String?>(
+    (urlContainer) => urlContainer.url,
+    (urlContainer, url) => urlContainer.copyWith(url: url),
+  );
+
+  static final path = Lens<GitPackageDependency, String?>(
+    (pathContainer) => pathContainer.path,
+    (pathContainer, path) => pathContainer.copyWith(path: path),
+  );
+
+  static final resolvedRef = Lens<GitPackageDependency, String?>(
+    (resolvedRefContainer) => resolvedRefContainer.resolvedRef,
+    (resolvedRefContainer, resolvedRef) =>
+        resolvedRefContainer.copyWith(resolvedRef: resolvedRef),
+  );
+
+  static final type = Lens<GitPackageDependency, DependencyType?>(
+    (typeContainer) => typeContainer.type,
+    (typeContainer, type) => typeContainer.copyWith(type: type),
+  );
+}

--- a/lib/src/package_dependency/git_package_dependency/serializers.dart
+++ b/lib/src/package_dependency/git_package_dependency/serializers.dart
@@ -34,12 +34,12 @@ GitPackageDependency loadGitPackageDependency(MapEntry<String, dynamic> entry) {
   final description = definition[_Tokens.description] as Map<String, dynamic>;
   return GitPackageDependency(
     package: entry.key,
-    version: definition[_Tokens.version] as String,
-    ref: description[_Tokens.ref] as String,
-    url: description[_Tokens.url] as String,
-    path: description[_Tokens.path] as String,
-    resolvedRef: description[_Tokens.resolvedRef] as String,
-    type: (definition[_Tokens.dependency] as String).parseDependencyType(),
+    version: definition[_Tokens.version] as String?,
+    ref: description[_Tokens.ref] as String?,
+    url: description[_Tokens.url] as String?,
+    path: description[_Tokens.path] as String?,
+    resolvedRef: description[_Tokens.resolvedRef] as String?,
+    type: (definition[_Tokens.dependency] as String?).parseDependencyType(),
   );
 }
 

--- a/lib/src/package_dependency/hosted_package_dependency/hosted_package_dependency.dart
+++ b/lib/src/package_dependency/hosted_package_dependency/hosted_package_dependency.dart
@@ -38,17 +38,17 @@ part 'hosted_package_dependency.g.dart';
 class HostedPackageDependency extends $HostedPackageDependency {
   /// Default constructor
   const HostedPackageDependency({
-    @required this.package,
-    @required this.version,
-    @required this.name,
-    @required this.url,
-    @required this.type,
+    required this.package,
+    required this.version,
+    required this.name,
+    required this.url,
+    required this.type,
   });
 
   final String package;
-  final String version;
+  final String? version;
 
-  final String name;
-  final String url;
-  final DependencyType type;
+  final String? name;
+  final String? url;
+  final DependencyType? type;
 }

--- a/lib/src/package_dependency/hosted_package_dependency/hosted_package_dependency.g.dart
+++ b/lib/src/package_dependency/hosted_package_dependency/hosted_package_dependency.g.dart
@@ -6,41 +6,45 @@ part of 'hosted_package_dependency.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $HostedPackageDependency {
   const $HostedPackageDependency();
+
   String get package;
-  String get version;
-  String get name;
-  String get url;
-  DependencyType get type;
+  String? get version;
+  String? get name;
+  String? get url;
+  DependencyType? get type;
+
   HostedPackageDependency copyWith(
-          {String package,
-          String version,
-          String name,
-          String url,
-          DependencyType type}) =>
+          {String? package,
+          String? version,
+          String? name,
+          String? url,
+          DependencyType? type}) =>
       HostedPackageDependency(
           package: package ?? this.package,
           version: version ?? this.version,
           name: name ?? this.name,
           url: url ?? this.url,
           type: type ?? this.type);
+
   @override
   String toString() =>
       "HostedPackageDependency(package: $package, version: $version, name: $name, url: $url, type: $type)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is HostedPackageDependency &&
       other.runtimeType == runtimeType &&
       package == other.package &&
       version == other.version &&
       name == other.name &&
       url == other.url &&
       type == other.type;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + package.hashCode;
@@ -52,25 +56,30 @@ abstract class $HostedPackageDependency {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class HostedPackageDependency$ {
   static final package = Lens<HostedPackageDependency, String>(
-      (s_) => s_.package, (s_, package) => s_.copyWith(package: package));
-  static final version = Lens<HostedPackageDependency, String>(
-      (s_) => s_.version, (s_, version) => s_.copyWith(version: version));
-  static final name = Lens<HostedPackageDependency, String>(
-      (s_) => s_.name, (s_, name) => s_.copyWith(name: name));
-  static final url = Lens<HostedPackageDependency, String>(
-      (s_) => s_.url, (s_, url) => s_.copyWith(url: url));
-  static final type = Lens<HostedPackageDependency, DependencyType>(
-      (s_) => s_.type, (s_, type) => s_.copyWith(type: type));
-}
+    (packageContainer) => packageContainer.package,
+    (packageContainer, package) => packageContainer.copyWith(package: package),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final version = Lens<HostedPackageDependency, String?>(
+    (versionContainer) => versionContainer.version,
+    (versionContainer, version) => versionContainer.copyWith(version: version),
+  );
+
+  static final name = Lens<HostedPackageDependency, String?>(
+    (nameContainer) => nameContainer.name,
+    (nameContainer, name) => nameContainer.copyWith(name: name),
+  );
+
+  static final url = Lens<HostedPackageDependency, String?>(
+    (urlContainer) => urlContainer.url,
+    (urlContainer, url) => urlContainer.copyWith(url: url),
+  );
+
+  static final type = Lens<HostedPackageDependency, DependencyType?>(
+    (typeContainer) => typeContainer.type,
+    (typeContainer, type) => typeContainer.copyWith(type: type),
+  );
+}

--- a/lib/src/package_dependency/hosted_package_dependency/serializers.dart
+++ b/lib/src/package_dependency/hosted_package_dependency/serializers.dart
@@ -36,9 +36,9 @@ HostedPackageDependency loadHostedPackageDependency(
   final description = definition[_Tokens.description] as Map<String, dynamic>;
   return HostedPackageDependency(
     package: entry.key,
-    version: definition[_Tokens.version] as String,
-    name: description[_Tokens.name] as String,
-    url: description[_Tokens.url] as String,
+    version: definition[_Tokens.version] as String?,
+    name: description[_Tokens.name] as String?,
+    url: description[_Tokens.url] as String?,
     type: (definition[_Tokens.dependency] as String).parseDependencyType(),
   );
 }

--- a/lib/src/package_dependency/package_dependency.dart
+++ b/lib/src/package_dependency/package_dependency.dart
@@ -53,7 +53,7 @@ class PackageDependency extends _$PackageDependency {
       );
 
   /// Provides package dependency version
-  String version() => iswitch(
+  String? version() => iswitch(
         sdk: (d) => d.version,
         hosted: (d) => d.version,
         git: (d) => d.version,
@@ -61,7 +61,7 @@ class PackageDependency extends _$PackageDependency {
       );
 
   /// Provides package dependency type -- direct, development, or transitive
-  DependencyType type() => iswitch(
+  DependencyType? type() => iswitch(
         sdk: (d) => d.type,
         hosted: (d) => d.type,
         git: (d) => d.type,

--- a/lib/src/package_dependency/package_dependency.g.dart
+++ b/lib/src/package_dependency/package_dependency.g.dart
@@ -23,22 +23,22 @@ abstract class _$PackageDependency {
         rec.hosted == null &&
         rec.git == null &&
         rec.path == null) {
-      return PackageDependency.sdk(rec.sdk);
+      return PackageDependency.sdk(rec.sdk!);
     } else if (rec.sdk == null &&
         rec.hosted != null &&
         rec.git == null &&
         rec.path == null) {
-      return PackageDependency.hosted(rec.hosted);
+      return PackageDependency.hosted(rec.hosted!);
     } else if (rec.sdk == null &&
         rec.hosted == null &&
         rec.git != null &&
         rec.path == null) {
-      return PackageDependency.git(rec.git);
+      return PackageDependency.git(rec.git!);
     } else if (rec.sdk == null &&
         rec.hosted == null &&
         rec.git == null &&
         rec.path != null) {
-      return PackageDependency.path(rec.path);
+      return PackageDependency.path(rec.path!);
     } else {
       throw Exception("Cannot select a $PackageDependency case given $rec");
     }
@@ -46,10 +46,10 @@ abstract class _$PackageDependency {
 
   $T dump<$T>(
     $T Function({
-      SdkPackageDependency sdk,
-      HostedPackageDependency hosted,
-      GitPackageDependency git,
-      PathPackageDependency path,
+      SdkPackageDependency? sdk,
+      HostedPackageDependency? hosted,
+      GitPackageDependency? git,
+      PathPackageDependency? path,
     })
         make,
   ) {
@@ -62,19 +62,19 @@ abstract class _$PackageDependency {
   }
 
   $T iswitch<$T>({
-    @required $T Function(SdkPackageDependency) sdk,
-    @required $T Function(HostedPackageDependency) hosted,
-    @required $T Function(GitPackageDependency) git,
-    @required $T Function(PathPackageDependency) path,
+    required $T Function(SdkPackageDependency) sdk,
+    required $T Function(HostedPackageDependency) hosted,
+    required $T Function(GitPackageDependency) git,
+    required $T Function(PathPackageDependency) path,
   }) {
     if (this.sdk != null) {
-      return sdk(this.sdk);
+      return sdk(this.sdk!);
     } else if (this.hosted != null) {
-      return hosted(this.hosted);
+      return hosted(this.hosted!);
     } else if (this.git != null) {
-      return git(this.git);
+      return git(this.git!);
     } else if (this.path != null) {
-      return path(this.path);
+      return path(this.path!);
     } else {
       throw StateError(
           "an instance of $PackageDependency has no case selected");
@@ -82,13 +82,13 @@ abstract class _$PackageDependency {
   }
 
   $T iswitcho<$T>({
-    $T Function(SdkPackageDependency) sdk,
-    $T Function(HostedPackageDependency) hosted,
-    $T Function(GitPackageDependency) git,
-    $T Function(PathPackageDependency) path,
-    @required $T Function() otherwise,
+    $T Function(SdkPackageDependency)? sdk,
+    $T Function(HostedPackageDependency)? hosted,
+    $T Function(GitPackageDependency)? git,
+    $T Function(PathPackageDependency)? path,
+    required $T Function() otherwise,
   }) {
-    $T _otherwise(Object _) => otherwise();
+    $T _otherwise(Object? _) => otherwise();
     return iswitch(
       sdk: sdk ?? _otherwise,
       hosted: hosted ?? _otherwise,
@@ -130,28 +130,18 @@ abstract class _$PackageDependency {
   }
 
   @protected
-  final SdkPackageDependency sdk;
+  final SdkPackageDependency? sdk;
   @protected
-  final HostedPackageDependency hosted;
+  final HostedPackageDependency? hosted;
   @protected
-  final GitPackageDependency git;
+  final GitPackageDependency? git;
   @protected
-  final PathPackageDependency path;
+  final PathPackageDependency? path;
 }
 
 abstract class PackageDependencyRecordBase<Self> {
-  SdkPackageDependency get sdk;
-  HostedPackageDependency get hosted;
-  GitPackageDependency get git;
-  PathPackageDependency get path;
+  SdkPackageDependency? get sdk;
+  HostedPackageDependency? get hosted;
+  GitPackageDependency? get git;
+  PathPackageDependency? get path;
 }
-
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element

--- a/lib/src/package_dependency/path_package_dependency/path_package_dependency.dart
+++ b/lib/src/package_dependency/path_package_dependency/path_package_dependency.dart
@@ -38,18 +38,18 @@ part 'path_package_dependency.g.dart';
 class PathPackageDependency extends $PathPackageDependency {
   /// Default constructor
   const PathPackageDependency({
-    @required this.package,
-    @required this.version,
-    @required this.path,
-    @required this.relative,
-    @required this.type,
+    required this.package,
+    required this.version,
+    required this.path,
+    required this.relative,
+    required this.type,
   });
 
   final String package;
-  final String version;
+  final String? version;
 
-  final String path;
-  final bool relative;
+  final String? path;
+  final bool? relative;
 
-  final DependencyType type;
+  final DependencyType? type;
 }

--- a/lib/src/package_dependency/path_package_dependency/path_package_dependency.g.dart
+++ b/lib/src/package_dependency/path_package_dependency/path_package_dependency.g.dart
@@ -6,41 +6,45 @@ part of 'path_package_dependency.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $PathPackageDependency {
   const $PathPackageDependency();
+
   String get package;
-  String get version;
-  String get path;
-  bool get relative;
-  DependencyType get type;
+  String? get version;
+  String? get path;
+  bool? get relative;
+  DependencyType? get type;
+
   PathPackageDependency copyWith(
-          {String package,
-          String version,
-          String path,
-          bool relative,
-          DependencyType type}) =>
+          {String? package,
+          String? version,
+          String? path,
+          bool? relative,
+          DependencyType? type}) =>
       PathPackageDependency(
           package: package ?? this.package,
           version: version ?? this.version,
           path: path ?? this.path,
           relative: relative ?? this.relative,
           type: type ?? this.type);
+
   @override
   String toString() =>
       "PathPackageDependency(package: $package, version: $version, path: $path, relative: $relative, type: $type)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is PathPackageDependency &&
       other.runtimeType == runtimeType &&
       package == other.package &&
       version == other.version &&
       path == other.path &&
       relative == other.relative &&
       type == other.type;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + package.hashCode;
@@ -52,25 +56,31 @@ abstract class $PathPackageDependency {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class PathPackageDependency$ {
   static final package = Lens<PathPackageDependency, String>(
-      (s_) => s_.package, (s_, package) => s_.copyWith(package: package));
-  static final version = Lens<PathPackageDependency, String>(
-      (s_) => s_.version, (s_, version) => s_.copyWith(version: version));
-  static final path = Lens<PathPackageDependency, String>(
-      (s_) => s_.path, (s_, path) => s_.copyWith(path: path));
-  static final relative = Lens<PathPackageDependency, bool>(
-      (s_) => s_.relative, (s_, relative) => s_.copyWith(relative: relative));
-  static final type = Lens<PathPackageDependency, DependencyType>(
-      (s_) => s_.type, (s_, type) => s_.copyWith(type: type));
-}
+    (packageContainer) => packageContainer.package,
+    (packageContainer, package) => packageContainer.copyWith(package: package),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final version = Lens<PathPackageDependency, String?>(
+    (versionContainer) => versionContainer.version,
+    (versionContainer, version) => versionContainer.copyWith(version: version),
+  );
+
+  static final path = Lens<PathPackageDependency, String?>(
+    (pathContainer) => pathContainer.path,
+    (pathContainer, path) => pathContainer.copyWith(path: path),
+  );
+
+  static final relative = Lens<PathPackageDependency, bool?>(
+    (relativeContainer) => relativeContainer.relative,
+    (relativeContainer, relative) =>
+        relativeContainer.copyWith(relative: relative),
+  );
+
+  static final type = Lens<PathPackageDependency, DependencyType?>(
+    (typeContainer) => typeContainer.type,
+    (typeContainer, type) => typeContainer.copyWith(type: type),
+  );
+}

--- a/lib/src/package_dependency/path_package_dependency/serializers.dart
+++ b/lib/src/package_dependency/path_package_dependency/serializers.dart
@@ -36,10 +36,10 @@ PathPackageDependency loadPathPackageDependency(
   final description = definition[_Tokens.description] as Map<String, dynamic>;
   return PathPackageDependency(
     package: entry.key,
-    version: definition[_Tokens.version] as String,
-    path: description[_Tokens.path] as String,
-    relative: description[_Tokens.relative] as bool,
-    type: (definition[_Tokens.dependency] as String).parseDependencyType(),
+    version: definition[_Tokens.version] as String?,
+    path: description[_Tokens.path] as String?,
+    relative: description[_Tokens.relative] as bool?,
+    type: (definition[_Tokens.dependency] as String?).parseDependencyType(),
   );
 }
 

--- a/lib/src/package_dependency/sdk_package_dependency/sdk_package_dependency.dart
+++ b/lib/src/package_dependency/sdk_package_dependency/sdk_package_dependency.dart
@@ -38,14 +38,14 @@ part 'sdk_package_dependency.g.dart';
 class SdkPackageDependency extends $SdkPackageDependency {
   /// Default constructor
   const SdkPackageDependency({
-    @required this.package,
-    @required this.version,
-    @required this.description,
-    @required this.type,
+    required this.package,
+    required this.version,
+    required this.description,
+    required this.type,
   });
 
   final String package;
-  final String version;
-  final String description;
-  final DependencyType type;
+  final String? version;
+  final String? description;
+  final DependencyType? type;
 }

--- a/lib/src/package_dependency/sdk_package_dependency/sdk_package_dependency.g.dart
+++ b/lib/src/package_dependency/sdk_package_dependency/sdk_package_dependency.g.dart
@@ -6,37 +6,41 @@ part of 'sdk_package_dependency.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $SdkPackageDependency {
   const $SdkPackageDependency();
+
   String get package;
-  String get version;
-  String get description;
-  DependencyType get type;
+  String? get version;
+  String? get description;
+  DependencyType? get type;
+
   SdkPackageDependency copyWith(
-          {String package,
-          String version,
-          String description,
-          DependencyType type}) =>
+          {String? package,
+          String? version,
+          String? description,
+          DependencyType? type}) =>
       SdkPackageDependency(
           package: package ?? this.package,
           version: version ?? this.version,
           description: description ?? this.description,
           type: type ?? this.type);
+
   @override
   String toString() =>
       "SdkPackageDependency(package: $package, version: $version, description: $description, type: $type)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is SdkPackageDependency &&
       other.runtimeType == runtimeType &&
       package == other.package &&
       version == other.version &&
       description == other.description &&
       type == other.type;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + package.hashCode;
@@ -47,24 +51,26 @@ abstract class $SdkPackageDependency {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class SdkPackageDependency$ {
   static final package = Lens<SdkPackageDependency, String>(
-      (s_) => s_.package, (s_, package) => s_.copyWith(package: package));
-  static final version = Lens<SdkPackageDependency, String>(
-      (s_) => s_.version, (s_, version) => s_.copyWith(version: version));
-  static final description = Lens<SdkPackageDependency, String>(
-      (s_) => s_.description,
-      (s_, description) => s_.copyWith(description: description));
-  static final type = Lens<SdkPackageDependency, DependencyType>(
-      (s_) => s_.type, (s_, type) => s_.copyWith(type: type));
-}
+    (packageContainer) => packageContainer.package,
+    (packageContainer, package) => packageContainer.copyWith(package: package),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final version = Lens<SdkPackageDependency, String?>(
+    (versionContainer) => versionContainer.version,
+    (versionContainer, version) => versionContainer.copyWith(version: version),
+  );
+
+  static final description = Lens<SdkPackageDependency, String?>(
+    (descriptionContainer) => descriptionContainer.description,
+    (descriptionContainer, description) =>
+        descriptionContainer.copyWith(description: description),
+  );
+
+  static final type = Lens<SdkPackageDependency, DependencyType?>(
+    (typeContainer) => typeContainer.type,
+    (typeContainer, type) => typeContainer.copyWith(type: type),
+  );
+}

--- a/lib/src/package_dependency/sdk_package_dependency/serializers.dart
+++ b/lib/src/package_dependency/sdk_package_dependency/serializers.dart
@@ -33,9 +33,9 @@ SdkPackageDependency loadSdkPackageDependency(MapEntry<String, dynamic> entry) {
   final definition = entry.value as Map<String, dynamic>;
   return SdkPackageDependency(
     package: entry.key,
-    version: definition[_Tokens.version] as String,
-    description: definition[_Tokens.description] as String,
-    type: (definition[_Tokens.dependency] as String).parseDependencyType(),
+    version: definition[_Tokens.version] as String?,
+    description: definition[_Tokens.description] as String?,
+    type: (definition[_Tokens.dependency] as String?).parseDependencyType(),
   );
 }
 

--- a/lib/src/package_dependency/serializers.dart
+++ b/lib/src/package_dependency/serializers.dart
@@ -34,7 +34,7 @@ import 'sdk_package_dependency/serializers.dart';
 
 PackageDependency loadPackageDependency(MapEntry<String, dynamic> entry) {
   final definition = entry.value as Map<String, dynamic>;
-  final source = definition[_Tokens.source] as String;
+  final source = definition[_Tokens.source] as String?;
   if (source == _Tokens.sdk) {
     return PackageDependency.sdk(loadSdkPackageDependency(entry));
   } else if (source == _Tokens.hosted) {

--- a/lib/src/pubspec_lock.dart
+++ b/lib/src/pubspec_lock.dart
@@ -26,7 +26,6 @@
 import 'dart:convert';
 
 import 'package:functional_data/functional_data.dart';
-import 'package:json2yaml/json2yaml.dart';
 import 'package:meta/meta.dart';
 import 'package:yaml/yaml.dart';
 
@@ -80,12 +79,13 @@ extension PubspecLockFromYamlString on String {
 }
 
 Iterable<PackageDependency> _loadPackages(Map<String, dynamic> jsonMap) =>
-    ((jsonMap[_Tokens.packages] as Map<String, dynamic>) ?? <String, dynamic>{})
+    // ignore: lines_longer_than_80_chars
+    ((jsonMap[_Tokens.packages] as Map<String, dynamic>?) ?? <String, dynamic>{})
         .entries
         .map(loadPackageDependency);
 
 Iterable<SdkDependency> _loadSdks(Map<String, dynamic> jsonMap) =>
-    ((jsonMap[_Tokens.sdks] as Map<String, dynamic>) ?? <String, dynamic>{})
+    ((jsonMap[_Tokens.sdks] as Map<String, dynamic>?) ?? <String, dynamic>{})
         .entries
         .map(loadSdkDependency);
 

--- a/lib/src/pubspec_lock.g.dart
+++ b/lib/src/pubspec_lock.g.dart
@@ -6,26 +6,30 @@ part of 'pubspec_lock.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $PubspecLock {
   const $PubspecLock();
+
   Iterable<SdkDependency> get sdks;
   Iterable<PackageDependency> get packages;
+
   PubspecLock copyWith(
-          {Iterable<SdkDependency> sdks,
-          Iterable<PackageDependency> packages}) =>
+          {Iterable<SdkDependency>? sdks,
+          Iterable<PackageDependency>? packages}) =>
       PubspecLock(sdks: sdks ?? this.sdks, packages: packages ?? this.packages);
+
   @override
   String toString() => "PubspecLock(sdks: $sdks, packages: $packages)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is PubspecLock &&
       other.runtimeType == runtimeType &&
       sdks == other.sdks &&
       packages == other.packages;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + sdks.hashCode;
@@ -34,19 +38,16 @@ abstract class $PubspecLock {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class PubspecLock$ {
   static final sdks = Lens<PubspecLock, Iterable<SdkDependency>>(
-      (s_) => s_.sdks, (s_, sdks) => s_.copyWith(sdks: sdks));
-  static final packages = Lens<PubspecLock, Iterable<PackageDependency>>(
-      (s_) => s_.packages, (s_, packages) => s_.copyWith(packages: packages));
-}
+    (sdksContainer) => sdksContainer.sdks,
+    (sdksContainer, sdks) => sdksContainer.copyWith(sdks: sdks),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final packages = Lens<PubspecLock, Iterable<PackageDependency>>(
+    (packagesContainer) => packagesContainer.packages,
+    (packagesContainer, packages) =>
+        packagesContainer.copyWith(packages: packages),
+  );
+}

--- a/lib/src/sdk_dependency/sdk_dependency.dart
+++ b/lib/src/sdk_dependency/sdk_dependency.dart
@@ -36,8 +36,8 @@ part 'sdk_dependency.g.dart';
 class SdkDependency extends $SdkDependency {
   /// Default constructor
   const SdkDependency({
-    @required this.sdk,
-    @required this.version,
+    required this.sdk,
+    required this.version,
   });
 
   final String sdk;

--- a/lib/src/sdk_dependency/sdk_dependency.g.dart
+++ b/lib/src/sdk_dependency/sdk_dependency.g.dart
@@ -6,24 +6,28 @@ part of 'sdk_dependency.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $SdkDependency {
   const $SdkDependency();
+
   String get sdk;
   String get version;
-  SdkDependency copyWith({String sdk, String version}) =>
+
+  SdkDependency copyWith({String? sdk, String? version}) =>
       SdkDependency(sdk: sdk ?? this.sdk, version: version ?? this.version);
+
   @override
   String toString() => "SdkDependency(sdk: $sdk, version: $version)";
+
   @override
-  bool operator ==(dynamic other) =>
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) =>
+      other is SdkDependency &&
       other.runtimeType == runtimeType &&
       sdk == other.sdk &&
       version == other.version;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + sdk.hashCode;
@@ -32,19 +36,15 @@ abstract class $SdkDependency {
   }
 }
 
+// ignore: avoid_classes_with_only_static_members
 class SdkDependency$ {
   static final sdk = Lens<SdkDependency, String>(
-      (s_) => s_.sdk, (s_, sdk) => s_.copyWith(sdk: sdk));
-  static final version = Lens<SdkDependency, String>(
-      (s_) => s_.version, (s_, version) => s_.copyWith(version: version));
-}
+    (sdkContainer) => sdkContainer.sdk,
+    (sdkContainer, sdk) => sdkContainer.copyWith(sdk: sdk),
+  );
 
-// ignore_for_file: always_put_required_named_parameters_first
-// ignore_for_file: avoid_annotating_with_dynamic
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
-// ignore_for_file: lines_longer_than_80_chars
-// ignore_for_file: prefer_asserts_with_message
-// ignore_for_file: prefer_expression_function_bodies
-// ignore_for_file: prefer_single_quotes
-// ignore_for_file: public_member_api_docs
-// ignore_for_file: unused_element
+  static final version = Lens<SdkDependency, String>(
+    (versionContainer) => versionContainer.version,
+    (versionContainer, version) => versionContainer.copyWith(version: version),
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,22 +1,21 @@
 name: pubspec_lock
 description: Dart library to access and manipulate content of pubpec.lock files
-version: 2.0.1+1
+version: 3.0.0
 homepage: https://github.com/alexei-sintotski/pubspec_lock
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  meta: ^1.1.8
-  functional_data: ^0.3.0
+  functional_data: ^1.0.0
   json2yaml: ^1.0.1
-  sum_types: ^0.2.1
-  yaml: ^2.2.0
+  meta: ^1.1.8
+  sum_types: ^0.3.0
+  yaml: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^1.7.2
-  dependency_validator: ^2.0.0
-  functional_data_generator: ^0.3.0
-  sum_types_generator: ^0.2.1
+  build_runner: ^2.0.0
+  dependency_validator: ^3.0.0
+  functional_data_generator: ^1.0.2
+  sum_types_generator: ^0.3.0
   test: ^1.9.4
-  test_coverage: ^0.5.0

--- a/test/git_package_dependency_test.dart
+++ b/test/git_package_dependency_test.dart
@@ -102,7 +102,7 @@ bool isGitDependency(PackageDependency dependency) => dependency.iswitcho(
       otherwise: () => false,
     );
 
-GitPackageDependency gitPackageDependency(PackageDependency dependency) =>
+GitPackageDependency? gitPackageDependency(PackageDependency dependency) =>
     dependency.iswitcho(
       git: (d) => d,
       otherwise: () => null,

--- a/test/hosted_package_dependency_test.dart
+++ b/test/hosted_package_dependency_test.dart
@@ -94,7 +94,8 @@ bool isHostedDependency(PackageDependency dependency) => dependency.iswitcho(
       otherwise: () => false,
     );
 
-HostedPackageDependency hostedPackageDependency(PackageDependency dependency) =>
+// ignore: lines_longer_than_80_chars
+HostedPackageDependency? hostedPackageDependency(PackageDependency dependency) =>
     dependency.iswitcho(
       hosted: (d) => d,
       otherwise: () => null,

--- a/test/path_package_dependency_test.dart
+++ b/test/path_package_dependency_test.dart
@@ -94,7 +94,7 @@ bool isPathDependency(PackageDependency dependency) => dependency.iswitcho(
       otherwise: () => false,
     );
 
-PathPackageDependency pathPackageDependency(PackageDependency dependency) =>
+PathPackageDependency? pathPackageDependency(PackageDependency dependency) =>
     dependency.iswitcho(
       path: (d) => d,
       otherwise: () => null,

--- a/test/sdk_package_dependency_test.dart
+++ b/test/sdk_package_dependency_test.dart
@@ -90,7 +90,7 @@ bool isSdkDependency(PackageDependency dependency) => dependency.iswitcho(
       otherwise: () => false,
     );
 
-SdkPackageDependency sdkPackageDependency(PackageDependency dependency) =>
+SdkPackageDependency? sdkPackageDependency(PackageDependency dependency) =>
     dependency.iswitcho(
       sdk: (d) => d,
       otherwise: () => null,

--- a/test/smoke_test.dart
+++ b/test/smoke_test.dart
@@ -50,7 +50,6 @@ void main() {
   });
 }
 
-// ignore: avoid_as
 String gitRepoRoot() =>
     (Process.runSync('git', ['rev-parse', '--show-toplevel']).stdout as String)
         .trim();


### PR DESCRIPTION
I did the minimal migration. Probably some things are nullable that don't have to be so.

TODO:

- [ ] Use migrated json2yaml [PR](https://github.com/alexei-sintotski/json2yaml/pull/14)
- [x] Use updated functional_data_generator instead of local path